### PR TITLE
CSF-882: Disable symlink on Windows

### DIFF
--- a/c++/src/capnp/CMakeLists.txt
+++ b/c++/src/capnp/CMakeLists.txt
@@ -222,8 +222,10 @@ if(NOT CAPNP_LITE)
 
   install(TARGETS capnp_tool capnpc_cpp capnpc_capnp ${INSTALL_TARGETS_DEFAULT_ARGS})
 
-  # Symlink capnpc -> capnp
-  install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink capnp \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnpc\")")
+  if(NOT WIN32)
+    # Symlink capnpc -> capnp
+    install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink capnp \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/capnpc\")")
+  endif()
 endif()  # NOT CAPNP_LITE
 
 # Tests ========================================================================


### PR DESCRIPTION
Windows requires admin rights to make symlinks. Disable since it generates a confusing error and doesn't appear to be necessary. Will eliminate the "good to go" message in `install_capnp.bat` separately.